### PR TITLE
Minor fixes to prevent github test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
   schedule:
-  - cron: '01 07 * * *'
+  - cron: '01 22 * * *'
 
   workflow_dispatch:
     inputs:
@@ -20,6 +20,8 @@ defaults:
 
 env:
   NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  # Allow ddev get to use a github token to prevent rate limiting by tests
+  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/skeemer/ddev-wkhtmltox/actions/workflows/tests.yml/badge.svg)](https://github.com/skeemer/ddev-wkhtmltox/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2022.svg)
+[![tests](https://github.com/skeemer/ddev-wkhtmltox/actions/workflows/tests.yml/badge.svg)](https://github.com/skeemer/ddev-wkhtmltox/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2023.svg)
 
 # DDEV-WKHTMLTOX
 


### PR DESCRIPTION
* Expose DDEV_GITHUB_TOKEN to prevent github from rate limiting
* Change maintained date to 2023