### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,14 @@ Using binaries compiled with patched Qt avoids a lot of fetch errors among other
 
 ## Getting started
 
-Install the add-on with ddev get skeemer/ddev-wkhtmltox
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get skeemer/ddev-wkhtmltox
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get skeemer/ddev-wkhtmltox
+```


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.